### PR TITLE
fix: do not remove `supportedVersion` key from `pallet-xcm` 

### DIFF
--- a/networks/astar.ts
+++ b/networks/astar.ts
@@ -31,7 +31,7 @@ export default {
       },
       PolkadotXcm: {
         // avoid sending xcm version change notifications to makes things faster
-        $removePrefix: ['versionNotifyTargets', 'versionNotifiers', 'supportedVersion'],
+        $removePrefix: ['versionNotifyTargets', 'versionNotifiers'],
       },
     },
   }),

--- a/tests/xcm-transfer/__snapshots__/astar-asset-hub.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/astar-asset-hub.test.ts.snap
@@ -106,8 +106,8 @@ exports[`Astar & AssetHub > 001: AssetHub transfer USDT to Astar > 002: astar ev
       },
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 890000000)",
+        "proofSize": "(rounded 9400)",
+        "refTime": "(rounded 900000000)",
       },
     },
     "method": "Processed",
@@ -122,7 +122,7 @@ exports[`Astar & AssetHub > 002: Astar transfer USDT to AssetHub > 001: astar um
     "data": [
       "ConcatenatedVersionedXcm",
       {
-        "v2": [
+        "v3": [
           {
             "withdrawAsset": [
               {
@@ -181,7 +181,7 @@ exports[`Astar & AssetHub > 002: Astar transfer USDT to AssetHub > 001: astar um
             "depositAsset": {
               "assets": {
                 "wild": {
-                  "all": null,
+                  "allCounted": 1,
                 },
               },
               "beneficiary": {
@@ -189,15 +189,12 @@ exports[`Astar & AssetHub > 002: Astar transfer USDT to AssetHub > 001: astar um
                   "x1": {
                     "accountId32": {
                       "id": "0xd17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69",
-                      "network": {
-                        "any": null,
-                      },
+                      "network": null,
                     },
                   },
                 },
                 "parents": 0,
               },
-              "maxAssets": 1,
             },
           },
         ],

--- a/tests/xcm-transfer/__snapshots__/kusama-shiden.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/kusama-shiden.test.ts.snap
@@ -158,7 +158,7 @@ exports[`Kusama & Shiden > 001: Kusama transfer KSM to Shiden > 003: shiden even
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 880000000)",
+        "refTime": "(rounded 900000000)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/__snapshots__/polkadot-astar.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/polkadot-astar.test.ts.snap
@@ -157,8 +157,8 @@ exports[`Polkadot & Astar > 001: Polkadot transfer DOT to Astar > 002: astar eve
       "origin": "Parent",
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 890000000)",
+        "proofSize": "(rounded 9400)",
+        "refTime": "(rounded 900000000)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/__snapshots__/shiden-asset-hub.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/shiden-asset-hub.test.ts.snap
@@ -107,7 +107,7 @@ exports[`Shiden & AssetHub > 001: AssetHub transfer USDT to Shiden > 002: shiden
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 880000000)",
+        "refTime": "(rounded 900000000)",
       },
     },
     "method": "Processed",
@@ -122,7 +122,7 @@ exports[`Shiden & AssetHub > 002: Shiden transfer USDT to AssetHub > 001: shiden
     "data": [
       "ConcatenatedVersionedXcm",
       {
-        "v2": [
+        "v3": [
           {
             "withdrawAsset": [
               {
@@ -181,7 +181,7 @@ exports[`Shiden & AssetHub > 002: Shiden transfer USDT to AssetHub > 001: shiden
             "depositAsset": {
               "assets": {
                 "wild": {
-                  "all": null,
+                  "allCounted": 1,
                 },
               },
               "beneficiary": {
@@ -189,15 +189,12 @@ exports[`Shiden & AssetHub > 002: Shiden transfer USDT to AssetHub > 001: shiden
                   "x1": {
                     "accountId32": {
                       "id": "0xd17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69",
-                      "network": {
-                        "any": null,
-                      },
+                      "network": null,
                     },
                   },
                 },
                 "parents": 0,
               },
-              "maxAssets": 1,
             },
           },
         ],


### PR DESCRIPTION
## Summary
- Update the snapshots
- Keep the `supportedVersion` storage from pallet-xcm

## Why?
With the new XCMv5, the deprecated XCMv2 has been completely removed. Hence any conversion to XCM v2 will result in error.

Previously, to speed-up things we removed the all the keys related to version notification from pallet-xcm, this included the `supportedVersion` which stored remote locations latest supported xcm version. Hence when sending xcm in the absence of `supportedVersion` the pallet-xcm convert the outgoing xcm to version stored in `SafeXcmVersion`.

The `SafeXcmVersion` is currently set to 2 in all our runtimes, and V2 has been completely removed so this conversion will fail now and thus XCM message couldn't being send