### PR TITLE
fix: redact weights keys from snapshots temprarily

### DIFF
--- a/tests/xcm-transfer/__snapshots__/astar-asset-hub.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/astar-asset-hub.test.ts.snap
@@ -106,8 +106,8 @@ exports[`Astar & AssetHub > 001: AssetHub transfer USDT to Astar > 002: astar ev
       },
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9400)",
-        "refTime": "(rounded 900000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/__snapshots__/kusama-shiden.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/kusama-shiden.test.ts.snap
@@ -144,8 +144,8 @@ exports[`Kusama & Shiden > 001: Kusama transfer KSM to Shiden > 003: shiden even
     "data": {
       "dmqHead": "(hash)",
       "weightUsed": {
-        "proofSize": "(rounded 8000)",
-        "refTime": "(rounded 530000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "DownwardMessagesProcessed",
@@ -157,8 +157,8 @@ exports[`Kusama & Shiden > 001: Kusama transfer KSM to Shiden > 003: shiden even
       "origin": "Parent",
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 900000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/__snapshots__/polkadot-astar.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/polkadot-astar.test.ts.snap
@@ -144,8 +144,8 @@ exports[`Polkadot & Astar > 001: Polkadot transfer DOT to Astar > 002: astar eve
     "data": {
       "dmqHead": "(hash)",
       "weightUsed": {
-        "proofSize": "(rounded 8000)",
-        "refTime": "(rounded 530000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "DownwardMessagesProcessed",
@@ -157,8 +157,8 @@ exports[`Polkadot & Astar > 001: Polkadot transfer DOT to Astar > 002: astar eve
       "origin": "Parent",
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9400)",
-        "refTime": "(rounded 900000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/__snapshots__/shiden-asset-hub.test.ts.snap
+++ b/tests/xcm-transfer/__snapshots__/shiden-asset-hub.test.ts.snap
@@ -106,8 +106,8 @@ exports[`Shiden & AssetHub > 001: AssetHub transfer USDT to Shiden > 002: shiden
       },
       "success": true,
       "weightUsed": {
-        "proofSize": "(rounded 9300)",
-        "refTime": "(rounded 900000000)",
+        "proofSize": "(redacted)",
+        "refTime": "(redacted)",
       },
     },
     "method": "Processed",

--- a/tests/xcm-transfer/astar-asset-hub.test.ts
+++ b/tests/xcm-transfer/astar-asset-hub.test.ts
@@ -36,7 +36,10 @@ describe('Astar & AssetHub', () => {
         'Expected amount was not received',
       )
 
-      await checkSystemEvents(astar, 'xcmpQueue', 'messageQueue').toMatchSnapshot('002: astar event')
+      await checkSystemEvents(astar, 'xcmpQueue', 'messageQueue')
+        // TODO: remove this when astar is upgraded with runtime-1500
+        .redact({ redactKeys: /proofSize|refTime/ })
+        .toMatchSnapshot('002: astar event')
     },
   )
 

--- a/tests/xcm-transfer/kusama-shiden.test.ts
+++ b/tests/xcm-transfer/kusama-shiden.test.ts
@@ -28,9 +28,10 @@ describe('Kusama & Shiden', () => {
         'Expected amount was not received',
       )
 
-      await checkSystemEvents(shiden, 'parachainSystem', 'dmpQueue', 'messageQueue').toMatchSnapshot(
-        '003: shiden event',
-      )
+      await checkSystemEvents(shiden, 'parachainSystem', 'dmpQueue', 'messageQueue')
+        // TODO: remove this when shiden is upgraded with runtime-1500
+        .redact({ redactKeys: /proofSize|refTime/ })
+        .toMatchSnapshot('003: shiden event')
     },
   )
 

--- a/tests/xcm-transfer/polkadot-astar.test.ts
+++ b/tests/xcm-transfer/polkadot-astar.test.ts
@@ -28,7 +28,10 @@ describe('Polkadot & Astar', () => {
         'Expected amount was not received',
       )
 
-      await checkSystemEvents(astar, 'parachainSystem', 'dmpQueue', 'messageQueue').toMatchSnapshot('002: astar event')
+      await checkSystemEvents(astar, 'parachainSystem', 'dmpQueue', 'messageQueue')
+        // TODO: remove this when astar is upgraded with runtime-1500
+        .redact({ redactKeys: /proofSize|refTime/ })
+        .toMatchSnapshot('002: astar event')
     },
   )
 

--- a/tests/xcm-transfer/shiden-asset-hub.test.ts
+++ b/tests/xcm-transfer/shiden-asset-hub.test.ts
@@ -36,7 +36,10 @@ describe('Shiden & AssetHub', () => {
         'Expected amount was not received',
       )
 
-      await checkSystemEvents(shiden, 'xcmpQueue', 'messageQueue').toMatchSnapshot('002: shiden event')
+      await checkSystemEvents(shiden, 'xcmpQueue', 'messageQueue')
+        // TODO: remove this when shiden is upgraded with runtime-1500
+        .redact({ redactKeys: /proofSize|refTime/ })
+        .toMatchSnapshot('002: shiden event')
     },
   )
 


### PR DESCRIPTION
 Ignore weights in snapshots temporarily till runtimes are upgraded -  https://github.com/AstarNetwork/e2e-tests/pull/122#pullrequestreview-2835381326